### PR TITLE
fix: accordion row cannot be removed

### DIFF
--- a/examples/AccordionWidget/package-lock.json
+++ b/examples/AccordionWidget/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "happeoaccordionwidget",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "happeoaccordionwidget",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@happeo/widget-sdk": "^0.1.23",

--- a/examples/AccordionWidget/package.json
+++ b/examples/AccordionWidget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happeoaccordionwidget",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Accordion widget for Happeo pages",
   "main": "index.js",
   "scripts": {

--- a/examples/AccordionWidget/src/AccordionWidget.js
+++ b/examples/AccordionWidget/src/AccordionWidget.js
@@ -108,12 +108,14 @@ const AccordionWidget = ({ id, editMode }) => {
         data.push(el.getContent());
       });
       widgetApi.setContent(JSON.stringify(data));
+      setItems(divideDataIntoRows(data));
     },
     200,
     { leading: false, trailing: true },
   );
 
   const removeRow = (index) => {
+    onItemUpdated();
     setItems((prevItems) => prevItems.filter((_, i) => i !== index));
   };
 


### PR DESCRIPTION
Fixes following issues

First Issue:

When creating the widget for the first time, and deleting the first item. The last item is deleted instead of the first one. Feel free to check GIF1

Steps to reproduce:

Create a new accordion widget.

Add a couple of rows.

Delete the first row in the widget. (as a result the last row will be deleted instead) GIF1

Issue can be avoided by saving the widget once creating it then the deletion will work as expected, it only appears the first time creating the widget.

 

Second Issue:

Deleting the last item in the accordion widget isn’t taking action after hitting save and refreshing the page. Feel free to check GIF2

Steps to reproduce:

Create an accordion widget, add some items, and Save.

Edit the widget and delete the last item, and Save.

Refresh the page ( the deleted item will appear again) GIF2