### PR TITLE
fix - [VanillaJS] webpack config for production, connectedCallback

### DIFF
--- a/VanillaJS/src/index.js
+++ b/VanillaJS/src/index.js
@@ -57,15 +57,15 @@ class happeoCustomWidget extends HTMLElement {
     wrapper.appendChild(title);
     wrapper.appendChild(text);
     wrapper.appendChild(list);
+  }
 
+  connectedCallback() {
     this.doInit();
   }
 
   async doInit() {
     // Init API
-    const widgetApi = await WidgetSDK.api.init(
-      this.attributes.getNamedItem("uniqueId").value
-    );
+    const widgetApi = await WidgetSDK.api.init(this.getAttribute("uniqueId"));
 
     // Use the SDK to get user and display it
     this.user = await widgetApi.getCurrentUser();

--- a/VanillaJS/webpack.config.js
+++ b/VanillaJS/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = (env) => {
     entry: path.join(__dirname, "src", "index.js"),
     mode: isProd ? "production" : "development",
     plugins: isProd
-      ? []
+      ? [new webpack.EnvironmentPlugin({ MOCK_WIDGET_SDK: false })]
       : [new webpack.EnvironmentPlugin({ MOCK_WIDGET_SDK: true })],
     module: {
       rules: [


### PR DESCRIPTION
- Fixes issue with production build where process was undefined. Webpack env plugin is required to explicitly specify `MOCK_WIDGET_SDK=false`
- Fixes uniqueid attribute missing issue. `connectedCallback` should be used to run initialisation. 